### PR TITLE
custom ghpages  config to point to `master` branch

### DIFF
--- a/cityscope/src/index.js
+++ b/cityscope/src/index.js
@@ -1,6 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
+import ghpages
+
+ghpages.publish('doc', {
+  branch: 'master',
+  repo: 'https://github.com/CityScience/cityscope.github.io.git'
+}, function(err){});
 
 ReactDOM.render(
     <React.StrictMode>


### PR DESCRIPTION
fixes #18

**cause**: Github Pages for org does not use `gh_pages` branch when deployed.
**solution**: This builds it to the same repo `master` branch. At the same time, the *actual* source repo should set the base branch as something else like `dev`. Contributors will naturally clone this `dev` branch and send PR's to `dev`. To deploy the maintainer can merge `dev` to `master`

This is to show the intent of what I meant. We need to double-check my usage of the `gh-pages` module is correct.